### PR TITLE
Bump node_version to 5.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ __Here's a full config file with all available options:__
 
 ```bash
 # We can set the version of Node to use for the app here
-node_version=0.12.4
+node_version=5.3.0
 
 # We can set the version of NPM to use for the app here
 npm_version=2.10.1

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,3 +1,3 @@
-node_version=0.12.4
+node_version=5.3.0
 config_vars_to_export=(DATABASE_URL)
 compile="compile"


### PR DESCRIPTION
This addresses an issue when trying to compile assets in when using Phoenix 1.1.0.

See https://github.com/phoenixframework/phoenix/issues/1410 for more details.