### PR TITLE
Update for Phoenix 1.1.2 and Brunch 2.1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -24,13 +24,13 @@ export_mix_env
 
 cached_node=$cache_dir/node-v$node_version-linux-x64.tar.gz
 
-head "Building dependencies"
-install_and_cache_deps
-
 head "Installing binaries"
 download_node
 install_node
 install_npm
+
+head "Building dependencies"
+install_and_cache_npm_deps
 
 compile
 

--- a/bin/compile
+++ b/bin/compile
@@ -24,13 +24,14 @@ export_mix_env
 
 cached_node=$cache_dir/node-v$node_version-linux-x64.tar.gz
 
+head "Building dependencies"
+install_and_cache_deps
+
 head "Installing binaries"
 download_node
 install_node
 install_npm
 
-head "Building dependencies"
-install_and_cache_deps
 compile
 
 head "Finalizing build"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -43,19 +43,23 @@ install_npm() {
     info "Using default npm version"
   else
     info "Downloading and installing npm $npm_version (replacing version `npm --version`)..."
+    cd $build_dir
     npm install --unsafe-perm --quiet -g npm@$npm_version 2>&1 >/dev/null | indent
   fi
 }
 
-install_and_cache_deps() {
+install_and_cache_npm_deps() {
   info "Installing and caching node modules"
-  cd $cache_dir
-  cp -f $build_dir/package.json ./
+  cd $build_dir
+  if [ -d $cache_dir/node_modules ]; then
+    mkdir -p node_modules
+    cp -r $cache_dir/node_modules/* node_modules/
+  fi
 
   npm install --quiet --unsafe-perm --userconfig $build_dir/npmrc 2>&1 | indent
   npm rebuild 2>&1 | indent
   npm --unsafe-perm prune 2>&1 | indent
-  cp -r node_modules $build_dir
+  cp -r node_modules $cache_dir
   PATH=$build_dir/node_modules/.bin:$PATH
   install_bower_deps
   cd - > /dev/null

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,3 +1,3 @@
-node_version=0.12.4
+node_version=5.3.0
 config_vars_to_export=(DATABASE_URL)
 compile="compile"


### PR DESCRIPTION
mix deps.get must be run before npm install so 
that the local deps/phoenix and deps/phoenix_html npm packages are available.