### PR TITLE
Fix cp failures

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -62,7 +62,6 @@ install_and_cache_npm_deps() {
   cp -r node_modules $cache_dir
   PATH=$build_dir/node_modules/.bin:$PATH
   install_bower_deps
-  cd - > /dev/null
 }
 
 install_bower_deps() {
@@ -81,8 +80,6 @@ compile() {
   PATH=$build_dir/.platform_tools/elixir/bin:$PATH
 
   run_compile
-
-  cd - > /dev/null
 }
 
 run_compile() {

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -71,9 +71,7 @@ install_bower_deps() {
 
   if [ -f $bower_json ]; then
     info "Installing and caching bower components"
-    cp -f $bower_json ./
     bower install
-    cp -r bower_components $build_dir
   fi
 }
 

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -66,7 +66,8 @@ install_and_cache_npm_deps() {
 }
 
 install_bower_deps() {
-  local bower_json=$build_dir/bower.json
+  cd $build_dir
+  local bower_json=bower.json
 
   if [ -f $bower_json ]; then
     info "Installing and caching bower components"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -66,11 +66,11 @@ install_and_cache_npm_deps() {
 }
 
 install_bower_deps() {
-  local bower_dir=$build_dir/bower.json
+  local bower_json=$build_dir/bower.json
 
-  if [ -f $bower_dir ]; then
+  if [ -f $bower_json ]; then
     info "Installing and caching bower components"
-    cp -f $bower_dir ./
+    cp -f $bower_json ./
     bower install
     cp -r bower_components $build_dir
   fi


### PR DESCRIPTION
* Fixes errors like: `cp: ‘/tmp/build_53960f7b097c02e37827c199ce104686/bower.json’ and ‘./bower.json’ are the same file`
* explicitly `cd`s to the necessary directory, so that each `function`'s body is self-descriptive
* avoids using `cd -`, because it makes it harder to know which dir you'll be jumping to (since it depends on the order of execution)