### PR TITLE
Support projects without package.json

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -31,15 +31,17 @@ load_config
 export_config_vars
 export_mix_env
 
-cached_node=$cache_dir/node-v$node_version-linux-x64.tar.gz
+if [ -e package.json ]; then
+  cached_node=$cache_dir/node-v$node_version-linux-x64.tar.gz
 
-head "Installing binaries"
-download_node
-install_node
-install_npm
+  head "Installing binaries"
+  download_node
+  install_node
+  install_npm
 
-head "Building dependencies"
-install_and_cache_npm_deps
+  head "Building dependencies"
+  install_and_cache_npm_deps
+fi
 
 compile
 

--- a/compile
+++ b/compile
@@ -1,2 +1,6 @@
-brunch build --production
+if [ -x "$(command -v brunch)" ]; then
+  brunch build --production
+else
+  echo "Brunch is not installed, not running!";
+fi
 mix phoenix.digest


### PR DESCRIPTION
Node is not required to run a phoenix server. This PR checks the existence of `package.json` to run the code related to node, avoiding errors in projects that don't have a package.json defined.