### PR TITLE
npm prune before install

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -84,6 +84,7 @@ install_and_cache_npm_deps() {
     cp -r $cache_dir/node_modules/* node_modules/
   fi
 
+  npm prune
   npm install --quiet --unsafe-perm --userconfig $build_dir/npmrc 2>&1 | indent
   npm rebuild 2>&1 | indent
   npm --unsafe-perm prune 2>&1 | indent

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -84,7 +84,7 @@ install_and_cache_npm_deps() {
     cp -r $cache_dir/node_modules/* node_modules/
   fi
 
-  npm prune
+  npm prune | indent
   npm install --quiet --unsafe-perm --userconfig $build_dir/npmrc 2>&1 | indent
   npm rebuild 2>&1 | indent
   npm --unsafe-perm prune 2>&1 | indent


### PR DESCRIPTION
Apparently npm doesn't actually work sometimes when dependencies change. A prune is required prior to install in certain cases (like upgrading from react-router 2.x to 3.0.0-alpha)