### PR TITLE
Replace brunch build with npm deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ just before finalizing the build. The `compile` file looks like this:
 
 ```bash
 info "Building Phoenix static assets"
-brunch build --production
+npm run deploy
 mix phoenix.digest
 ```
 
-To customize your app's compile hook, just add a `compile` file to your app's root directory.
+To customize your app's compile hook, you can either change the `deploy` script in `package.json` or add a `compile` file to your app's root directory.
 `compile` is just a shell script, so you can use any valid `bash` code. Keep in mind you'll have
 access to your `node_modules` and `mix`. This means that if you're using a Node build tool other than `brunch`, you can just do something like:
 

--- a/compile
+++ b/compile
@@ -1,2 +1,2 @@
-brunch build --production
+npm run deploy
 mix phoenix.digest


### PR DESCRIPTION
Phoenix ships a `package.json` that has a script called `deploy` which
can be used as a generic way to compile your assets during a deploy
instead of using brunch directly.

This change allows an application to change the `deploy` npm script
instead of having to provide a custom compile script.

Here's the template `package.json` Phoenix ships with.
https://github.com/phoenixframework/phoenix/blob/master/installer/templates/static/brunch/package.json