### PR TITLE
Add yarn support

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -36,9 +36,12 @@ cleanup_cache
 download_node
 install_node
 install_npm
+if [ -f "$build_dir/yarn.lock" ]; then
+  install_yarn "$heroku_dir/yarn"
+fi
 
 head "Building dependencies"
-install_and_cache_npm_deps
+install_and_cache_deps
 
 compile
 

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -76,7 +76,29 @@ install_npm() {
   fi
 }
 
-install_and_cache_npm_deps() {
+install_yarn() {
+  local dir="$1"
+
+  echo "Downloading and installing yarn..."
+  local download_url="https://yarnpkg.com/latest.tar.gz"
+  local code=$(curl "$download_url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
+  if [ "$code" != "200" ]; then
+    echo "Unable to download yarn: $code" && false
+  fi
+  rm -rf $dir
+  mkdir -p "$dir"
+  # https://github.com/yarnpkg/yarn/issues/770
+  if tar --version | grep -q 'gnu'; then
+    tar xzf /tmp/yarn.tar.gz -C "$dir" --strip 1 --warning=no-unknown-keyword
+  else
+    tar xzf /tmp/yarn.tar.gz -C "$dir" --strip 1
+  fi
+  chmod +x $dir/bin/*
+  PATH=$dir/bin:$PATH
+  echo "Installed yarn $(yarn --version)"
+}
+
+install_and_cache_deps() {
   info "Installing and caching node modules"
   cd $phoenix_dir
   if [ -d $cache_dir/node_modules ]; then
@@ -84,13 +106,26 @@ install_and_cache_npm_deps() {
     cp -r $cache_dir/node_modules/* node_modules/
   fi
 
+  if [ -f "$build_dir/yarn.lock" ]; then
+    install_yarn_deps
+  else
+    install_npm_deps
+  fi
+
+  cp -r node_modules $cache_dir
+  PATH=$phoenix_dir/node_modules/.bin:$PATH
+  install_bower_deps
+}
+
+install_npm_deps() {
   npm prune | indent
   npm install --quiet --unsafe-perm --userconfig $build_dir/npmrc 2>&1 | indent
   npm rebuild 2>&1 | indent
   npm --unsafe-perm prune 2>&1 | indent
-  cp -r node_modules $cache_dir
-  PATH=$phoenix_dir/node_modules/.bin:$PATH
-  install_bower_deps
+}
+
+install_yarn_deps() {
+  yarn install --pure-lockfile 2>&1
 }
 
 install_bower_deps() {
@@ -138,7 +173,7 @@ cache_versions() {
 write_profile() {
   info "Creating runtime environment"
   mkdir -p $build_dir/.profile.d
-  local export_line="export PATH=\"\$HOME/.heroku/node/bin:\$HOME/bin:\$HOME/$phoenix_relative_path/node_modules/.bin:\$PATH\"
+  local export_line="export PATH=\"\$HOME/.heroku/node/bin:\$HOME/.heroku/yarn/bin:\$HOME/bin:\$HOME/$phoenix_relative_path/node_modules/.bin:\$PATH\"
                      export MIX_ENV=${MIX_ENV}"
   echo $export_line >> $build_dir/.profile.d/phoenix_static_buildpack_paths.sh
 }


### PR DESCRIPTION
This is based heavily on https://github.com/heroku/heroku-buildpack-nodejs/compare/yarn

It appears to work for me. It'll only trigger if there is a `yarn.lock` in the root of the project.