### PR TITLE
Cache static between builds and use phoenix.digest.clean

### DIFF
--- a/compile
+++ b/compile
@@ -1,2 +1,6 @@
 brunch build --production
-mix do phoenix.digest, phoenix.digest.clean
+mix phoenix.digest
+
+if mix help phoenix.digest.clean 1>/dev/null 2>&1; then
+  mix phoenix.digest.clean
+fi

--- a/compile
+++ b/compile
@@ -1,2 +1,2 @@
 brunch build --production
-mix phoenix.digest
+mix do phoenix.digest, phoenix.digest.clean

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -4,6 +4,7 @@ cleanup_cache() {
     info "Cleaning out cache contents"
     rm -rf $cache_dir/npm-version
     rm -rf $cache_dir/node-version
+    rm -rf $cache_dir/phoenix-static
     rm -rf $cache_dir/yarn-cache
     cleanup_old_node
   fi
@@ -156,6 +157,11 @@ compile() {
 run_compile() {
   local custom_compile="${build_dir}/${compile}"
 
+  cd $phoenix_dir
+  mkdir -p $cache_dir/phoenix-static
+  info "Restoring cached assets"
+  rsync -a -v --ignore-existing $cache_dir/phoenix-static/ priv/static
+
   if [ -f $custom_compile ]; then
     info "Running custom compile"
     source $custom_compile 2>&1 | indent
@@ -163,6 +169,9 @@ run_compile() {
     info "Running default compile"
     source ${build_pack_dir}/${compile} 2>&1 | indent
   fi
+
+  info "Caching assets"
+  rsync -a -v priv/static/ $cache_dir/phoenix-static
 }
 
 cache_versions() {

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -158,9 +158,14 @@ run_compile() {
   local custom_compile="${build_dir}/${compile}"
 
   cd $phoenix_dir
-  mkdir -p $cache_dir/phoenix-static
-  info "Restoring cached assets"
-  rsync -a -v --ignore-existing $cache_dir/phoenix-static/ priv/static
+
+  has_clean=$(mix help phoenix.digest.clean 1>/dev/null 2>&1; echo $?)
+
+  if [ $has_clean = 0 ]; then
+    mkdir -p $cache_dir/phoenix-static
+    info "Restoring cached assets"
+    rsync -a -v --ignore-existing $cache_dir/phoenix-static/ priv/static
+  fi
 
   if [ -f $custom_compile ]; then
     info "Running custom compile"
@@ -170,8 +175,10 @@ run_compile() {
     source ${build_pack_dir}/${compile} 2>&1 | indent
   fi
 
-  info "Caching assets"
-  rsync -a -v priv/static/ $cache_dir/phoenix-static
+  if [ $has_clean = 0 ]; then
+    info "Caching assets"
+    rsync -a -v priv/static/ $cache_dir/phoenix-static
+  fi
 }
 
 cache_versions() {


### PR DESCRIPTION
Phoenix 1.3 will introduce `mix phoenix.digest.clean` which allows us to do what the ruby buildpack does and keep our old versions of assets cached and clean them intelligently.

Given that not everyone will upgrade immediately, this will probably need to be an option for the time being.