### PR TITLE
Update default Node from 5 to 6 LTS

### DIFF
--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,6 +1,6 @@
 clean_cache=false
 compile="compile"
 config_vars_to_export=(DATABASE_URL)
-node_version=5.3.0
+node_version=6.9.2
 phoenix_relative_path=.
 remove_node=false


### PR DESCRIPTION
One issue with the current configuration is Node 5 was never an LTS release, so moving this up to 6.9.2 brings it to LTS and the most applicable support for Phoenix applications.

The other major issue is that this release relies on NPM 2, which has a tiered module management system, causing some unwieldy and memory-intensive node applications. NPM 3 has a flat listing of node modules, which significantly reduces the size of some applications.

I discovered this change after trying to use the latest Babel, and running into issues deploying my application to Heroku. Once I split off of this config and opted for LTS, my application was able to deploy and my application size was down quite a bit.