### PR TITLE
Delete extraneous files when syncing static cache

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -177,7 +177,7 @@ run_compile() {
 
   if [ $has_clean = 0 ]; then
     info "Caching assets"
-    rsync -a -v priv/static/ $cache_dir/phoenix-static
+    rsync -a --delete -v priv/static/ $cache_dir/phoenix-static
   fi
 }
 


### PR DESCRIPTION
Previously, the cache would grow and grow even if `mix phoenix.digest.clean` was
deleting files, they wouldn't get deleted in the cache.