### PR TITLE
Add support for phoenix 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ phoenix_relative_path=.
 
 # Remove node and node_modules directory to keep slug size down if it is not needed.
 remove_node=false
+
+# We can change path that npm dependencies are in relation to phoenix app. E.g. assets for phoenix 1.3 support.
+assets_path=.
+
+# We can change phoenix mix namespace tasks. E.g. phx for phoenix 1.3 support.
+phoenix_ex=phoenix
 ```
 
 ## Compile
@@ -89,8 +95,12 @@ just before finalizing the build. The `compile` file looks like this:
 
 ```bash
 info "Building Phoenix static assets"
+
+cd assets
 brunch build --production
-mix phoenix.digest
+
+cd ..
+mix phx.digest
 ```
 
 To customize your app's compile hook, just add a `compile` file to your app's root directory.

--- a/bin/compile
+++ b/bin/compile
@@ -36,7 +36,7 @@ cleanup_cache
 download_node
 install_node
 install_npm
-if [ -f "$build_dir/yarn.lock" ]; then
+if [ -f "$assets_dir/yarn.lock" ]; then
   install_yarn "$heroku_dir/yarn"
 fi
 

--- a/compile
+++ b/compile
@@ -2,8 +2,8 @@ brunch build --production
 
 cd $phoenix_dir
 
-mix phoenix.digest
+mix "${phoenix_ex}.digest"
 
-if mix help phoenix.digest.clean 1>/dev/null 2>&1; then
-  mix phoenix.digest.clean
+if mix help "${phoenix_ex}.digest.clean" 1>/dev/null 2>&1; then
+  mix "${phoenix_ex}.digest.clean"
 fi

--- a/compile
+++ b/compile
@@ -1,4 +1,7 @@
 brunch build --production
+
+cd $phoenix_dir
+
 mix phoenix.digest
 
 if mix help phoenix.digest.clean 1>/dev/null 2>&1; then

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -108,7 +108,7 @@ install_and_cache_deps() {
     cp -r $cache_dir/node_modules/* node_modules/
   fi
 
-  if [ -f "$build_dir/yarn.lock" ]; then
+  if [ -f "$assets_dir/yarn.lock" ]; then
     install_yarn_deps
   else
     install_npm_deps

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -167,6 +167,8 @@ run_compile() {
     rsync -a -v --ignore-existing $cache_dir/phoenix-static/ priv/static
   fi
 
+  cd $assets_dir
+
   if [ -f $custom_compile ]; then
     info "Running custom compile"
     source $custom_compile 2>&1 | indent
@@ -174,6 +176,8 @@ run_compile() {
     info "Running default compile"
     source ${build_pack_dir}/${compile} 2>&1 | indent
   fi
+
+  cd $phoenix_dir
 
   if [ $has_clean = 0 ]; then
     info "Caching assets"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -159,7 +159,7 @@ run_compile() {
 
   cd $phoenix_dir
 
-  has_clean=$(mix help phoenix.digest.clean 1>/dev/null 2>&1; echo $?)
+  has_clean=$(mix help "${phoenix_ex}.digest.clean" 1>/dev/null 2>&1; echo $?)
 
   if [ $has_clean = 0 ]; then
     mkdir -p $cache_dir/phoenix-static

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -102,7 +102,7 @@ install_yarn() {
 
 install_and_cache_deps() {
   info "Installing and caching node modules"
-  cd $phoenix_dir
+  cd $assets_dir
   if [ -d $cache_dir/node_modules ]; then
     mkdir -p node_modules
     cp -r $cache_dir/node_modules/* node_modules/
@@ -115,7 +115,7 @@ install_and_cache_deps() {
   fi
 
   cp -r node_modules $cache_dir
-  PATH=$phoenix_dir/node_modules/.bin:$PATH
+  PATH=$assets_dir/node_modules/.bin:$PATH
   install_bower_deps
 }
 
@@ -131,7 +131,7 @@ install_yarn_deps() {
 }
 
 install_bower_deps() {
-  cd $phoenix_dir
+  cd $assets_dir
   local bower_json=bower.json
 
   if [ -f $bower_json ]; then
@@ -204,6 +204,6 @@ write_profile() {
 
 remove_node() {
   info "Removing node and node_modules"
-  rm -rf $phoenix_dir/node_modules
+  rm -rf $assets_dir/node_modules
   rm -rf $heroku_dir/node
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -38,6 +38,7 @@ load_config() {
   fi
 
   phoenix_dir=$build_dir/$phoenix_relative_path
+  assets_dir=$phoenix_dir/$assets_path
 
   info "Will use the following versions:"
   info "* Node ${node_version}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -38,7 +38,31 @@ load_config() {
   fi
 
   phoenix_dir=$build_dir/$phoenix_relative_path
+
+  info "Detecting assets directory"
+  if [ -f "$phoenix_dir/$assets_path/package.json" ]; then
+    # Check phoenix custom sub-directory for package.json
+    info "* package.json found in custom directory"
+  elif [ -f "$phoenix_dir/package.json" ]; then
+    # Check phoenix root directory for package.json, phoenix 1.2.x and prior
+    info "WARNING: package.json detected in root "
+    info "* assuming phoenix 1.2.x or prior, please check config file"
+
+    assets_path=.
+    phoenix_ex=phoenix
+  else
+    # Check phoenix custom sub-directory for package.json, phoenix 1.3.x and later
+    info "WARNING: no package.json detected in root nor custom directory"
+    info "* assuming phoenix 1.3.x and later, please check config file"
+
+    assets_path=assets
+    phoenix_ex=phx
+  fi
+
   assets_dir=$phoenix_dir/$assets_path
+  info "Will use phoenix configuration:"
+  info "* assets path ${assets_path}"
+  info "* mix tasks namespace ${phoenix_ex}"
 
   info "Will use the following versions:"
   info "* Node ${node_version}"

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -5,3 +5,4 @@ node_version=6.9.2
 phoenix_relative_path=.
 remove_node=false
 assets_path=.
+phoenix_ex=phoenix

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -4,3 +4,4 @@ config_vars_to_export=(DATABASE_URL)
 node_version=6.9.2
 phoenix_relative_path=.
 remove_node=false
+assets_path=.


### PR DESCRIPTION
Extract for possible configuration changes:
- ```assets_dir``` which for phoenix 1.3 is under ```assets``` instead root
- ```phoenix_ex``` for support of new phoenix mix tasks phoenixframework/phoenix#1927  

One topic to decide is default values for new config variables. For now they are set to match phoenix 1.2.x After official release they should be changed to match current phoenix conventions.

Updates #57