### PR TITLE
Create `priv/static` dir if it does not exist

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -159,6 +159,8 @@ run_compile() {
 
   cd $phoenix_dir
 
+  [[ -d priv/static ]] || mkdir -p priv/static
+
   has_clean=$(mix help "${phoenix_ex}.digest.clean" 1>/dev/null 2>&1; echo $?)
 
   if [ $has_clean = 0 ]; then


### PR DESCRIPTION
Fixes a problem where deployment will fail is `priv/static` does not exist. This could be a potential issue for Phoenix-based API projects.