### PR TITLE
switch to npm run to abstract the tool used

### DIFF
--- a/compile
+++ b/compile
@@ -1,4 +1,4 @@
-brunch build --production
+npm run deploy
 
 cd $phoenix_dir
 


### PR DESCRIPTION
For the default install of phoenix, this does not change anything but it allows for customisation of the deploy command if one wish for it.