### PR TITLE
add --check-files option to yarn install

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -127,7 +127,7 @@ install_npm_deps() {
 }
 
 install_yarn_deps() {
-  yarn install --cache-folder $cache_dir/yarn-cache --pure-lockfile 2>&1
+  yarn install --check-files --cache-folder $cache_dir/yarn-cache --pure-lockfile 2>&1
 }
 
 install_bower_deps() {


### PR DESCRIPTION
This adds the [--check-files](https://yarnpkg.com/en/docs/cli/install#toc-yarn-install-check-files) option to the `yarn install` command.

This will prevent problems in situations where the node_modules is missing files for some reason.  This could happen if the cached node_modules is bad for some reason.  

I specifically saw this issue happen when trying to use this buildpack on Cloud Foundry, which uploads deployed files from a local directory (as opposed to always checking out from git like Heroku).  I somehow got a bad cache uploaded, and was unable to get a successful build until I added this option to have yarn fill in missing files.  I could have avoided this I think if I'd had node_modules in the .cfignore from the beginning, but I didn't realize until it was too late.  Could have also force cleared the cache, but this was easier.

This adds a small amount of time to the build (just a few seconds, negligible really), but I think it's worth it for the reliability if the node_modules cache is bad for any reason.