### PR TITLE
Update nodejs version default to 6.11.1

### DIFF
--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,6 +1,6 @@
 clean_cache=false
 compile="compile"
-node_version=6.9.2
+node_version=6.11.1
 phoenix_relative_path=.
 remove_node=false
 assets_path=.


### PR DESCRIPTION
Update the default version of nodejs to fix the Node.js Constant Hashable Seeds vulnerability.

https://kb.heroku.com/node-js-constant-hashtable-seeds-vulnerability-faq
https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/