### PR TITLE
Create priv/ directory if it does not exist.

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -164,6 +164,7 @@ run_compile() {
   if [ $has_clean = 0 ]; then
     mkdir -p $cache_dir/phoenix-static
     info "Restoring cached assets"
+    mkdir -p priv
     rsync -a -v --ignore-existing $cache_dir/phoenix-static/ priv/static
   fi
 


### PR DESCRIPTION
I ran into this error when the priv folder does not exist and the cache is empty. My repo does not have a `priv/` folder and it feels weird for me to create an empty directory just to get this buildpack to work. 

```
rsync: change_dir#3 "/tmp/build//priv" failed: No such file or directory (2)
rsync error: errors selecting input/output files, dirs (code 3) at main.c(712) [Receiver=3.1.0]
```

I was able to reproduce the error by running this manually
```
root@6a03460d0f87:/tmp/build# rsync -a -v --ignore-existing /tmp/cache/phoenix-static/ priv/static
sending incremental file list
rsync: change_dir#3 "/tmp/build//priv" failed: No such file or directory (2)
rsync error: errors selecting input/output files, dirs (code 3) at main.c(712) [Receiver=3.1.0]
```

And the error goes away if I run
```
root@6a03460d0f87:/tmp/build# mkdir -p priv
root@6a03460d0f87:/tmp/build# rsync -a -v --ignore-existing /tmp/cache/phoenix-static/ priv/static
sending incremental file list
./

sent 61 bytes  received 19 bytes  160.00 bytes/sec
total size is 0  speedup is 0.00
```
Thanks for considering this!