### PR TITLE
Update to actual command to start the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This buildpack is meant to be used with the [Heroku Buildpack for Elixir](https:
 * Works much like the [Heroku Buildpack for Elixir](https://github.com/HashNuke/heroku-buildpack-elixir)!
 * **Easy configuration** with `phoenix_static_buildpack.config` file
 * Automatically sets `DATABASE_URL`
-* If your app doesn't have a Procfile, default web task `mix phoenix.server` will be run
+* If your app doesn't have a Procfile, default web task `mix phx.server` will be run
 * Can configure versions for Node and NPM
 * Auto-installs Bower deps if `bower.json` is in your app's root path
 * Caches Node, NPM modules and Bower components

--- a/bin/release
+++ b/bin/release
@@ -5,5 +5,5 @@ cat <<EOF
 addons:
   []
 default_process_types:
-  web: mix phoenix.server
+  web: mix phx.server
 EOF


### PR DESCRIPTION
# Description

While deploying the app generates the warning
```sh
mix phoenix.server is deprecated. Use phx.server instead.
```
Command must be updated before being discontinued

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Test A
Multiple projects (all with phoenix version >1.3) were deployed to Heroku using this change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings