### PR TITLE
Var in release

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
+# bin/release <build-dir>
+
+export BUILD_DIR=$1
 
 cat <<EOF
 ---
 addons:
   []
 default_process_types:
-  web: mix ${phoenix_ex}.server
 EOF
+
+if [ -f $BUILD_DIR/PHOENIX_EX_VAR ]; then
+  source $BUILD_DIR/PHOENIX_EX_VAR
+  echo "  web: mix ${phoenix_ex}.server"
+else
+  echo "  web: mix phx.server"
+fi

--- a/bin/release
+++ b/bin/release
@@ -2,17 +2,12 @@
 # bin/release <build-dir>
 
 export BUILD_DIR=$1
+source $BUILD_DIR/PHOENIX_EX_VAR
 
 cat <<EOF
 ---
 addons:
   []
 default_process_types:
+  web: mix ${phoenix_ex}.server
 EOF
-
-if [ -f $BUILD_DIR/PHOENIX_EX_VAR ]; then
-  source $BUILD_DIR/PHOENIX_EX_VAR
-  echo "  web: mix ${phoenix_ex}.server"
-else
-  echo "  web: mix phx.server"
-fi

--- a/bin/release
+++ b/bin/release
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 
-build_pack_dir=$(cd $(dirname $(dirname $0)); pwd)
-
-source ${build_pack_dir}/lib/common.sh
-
-head "Loading config in bin/release"
-load_config
-
 cat <<EOF
 ---
 addons:

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -30,19 +30,16 @@ load_config() {
   # Source for default versions file from buildpack first
   source "${build_pack_dir}/phoenix_static_buildpack.config"
 
-  if [ -f $custom_config_file ]; then
-    source $custom_config_file
-  else
-    info "WARNING: phoenix_static_buildpack.config wasn't found in the app"
-    info "Using default config from Phoenix static buildpack"
-  fi
-
   phoenix_dir=$build_dir/$phoenix_relative_path
 
   info "Detecting assets directory"
   if [ -f "$phoenix_dir/$assets_path/package.json" ]; then
     # Check phoenix custom sub-directory for package.json
-    info "* package.json found in custom directory"
+    info "* package.json found in assets directory"
+    info "* assuming phoenix 1.3.x and later, please check config file"
+    
+    assets_path=assets
+    phoenix_ex=phx
   elif [ -f "$phoenix_dir/package.json" ]; then
     # Check phoenix root directory for package.json, phoenix 1.2.x and prior
     info "WARNING: package.json detected in root "
@@ -59,7 +56,16 @@ load_config() {
     phoenix_ex=phx
   fi
 
+  # Override vars from custom config file if present
+  if [ -f $custom_config_file ]; then
+    source $custom_config_file
+  else
+    info "WARNING: phoenix_static_buildpack.config wasn't found in the app"
+    info "Using default config from Phoenix static buildpack"
+  fi
+
   assets_dir=$phoenix_dir/$assets_path
+
   info "Will use phoenix configuration:"
   info "* assets path ${assets_path}"
   info "* mix tasks namespace ${phoenix_ex}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -66,6 +66,9 @@ load_config() {
 
   assets_dir=$phoenix_dir/$assets_path
 
+  # save this value for bin/release
+  echo "phoenix_ex=${phoenix_ex}" > $build_dir/PHOENIX_EX_VAR
+
   info "Will use phoenix configuration:"
   info "* assets path ${assets_path}"
   info "* mix tasks namespace ${phoenix_ex}"

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -4,5 +4,5 @@ node_version=6.9.2
 yarn_version=0.27.5
 phoenix_relative_path=.
 remove_node=false
-assets_path=.
+assets_path=assets
 phoenix_ex=phx


### PR DESCRIPTION
passed `phoenix_ex` var from `lib/common.sh#load_config()` to `bin/release` through a small file generated in $BUILD_DIR.

Calling load_config() from inside `release` caused error, because of the messages echoed from load_config() were considered part of the YAML output generated by the release script.

also changed the logic of load_config(), bc phoenix 1.3.x apps have a package.json on ./assets/, that wasn't detected. and moved the sourcing of `phoenix_static_buildpack.config` at the end to override what was already set from the defaults if the file is present.