### PR TITLE
Updated to match the readme

### DIFF
--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -5,4 +5,4 @@ yarn_version=0.27.5
 phoenix_relative_path=.
 remove_node=false
 assets_path=.
-phoenix_ex=phoenix
+phoenix_ex=phx


### PR DESCRIPTION
https://github.com/gjaldon/heroku-buildpack-phoenix-static/commit/502afc8471cdec37fa46d94d1e85c6fa4c3a6872 was changed to use `phx` - so I'm assuming we would also want this file changed to reflect the same ... correct?