### PR TITLE
No warn for default

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -33,7 +33,7 @@ load_config() {
   if [ -f $custom_config_file ]; then
     source $custom_config_file
   else
-    info "WARNING: phoenix_static_buildpack.config wasn't found in the app"
+    info "phoenix_static_buildpack.config wasn't found in the app"
     info "Using default config from Phoenix static buildpack"
   fi
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -33,8 +33,8 @@ load_config() {
   if [ -f $custom_config_file ]; then
     source $custom_config_file
   else
-    info "phoenix_static_buildpack.config wasn't found in the app"
-    info "Using default config from Phoenix static buildpack"
+    info "The config file phoenix_static_buildpack.config wasn't found"
+    info "Using the default config provided from the Phoenix static buildpack"
   fi
 
   phoenix_dir=$build_dir/$phoenix_relative_path


### PR DESCRIPTION
I view following a convention, or a default, to be a good thing. When looking through the logs of a deployment, I get concerned with WARNING's. 

I thought this warning was a bit superfluous and misleading.