### PR TITLE
Support NPM_TOKEN to .npmrc and fix issue with prune

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -1,3 +1,5 @@
+
+ 
 cleanup_cache() {
   if [ $clean_cache = true ]; then
     info "clean_cache option set to true."
@@ -134,6 +136,13 @@ install_and_cache_deps() {
 }
 
 install_npm_deps() {
+  npm_token="${NPM_TOKEN:-$(cat $env_dir/NPM_TOKEN)}"
+
+  if [ "$npm_token" != "" ]; then
+    info "Adding npm registry entry to .npmrc using environment variable NPM_TOKEN"
+    echo "//registry.npmjs.org/:_authToken=${npm_token}" >> "${build_dir}/.npmrc"
+  fi
+  npm prune --userconfig $build_dir/.npmrc
   npm install --unsafe-perm --userconfig $build_dir/.npmrc 2>&1 | indent
   npm rebuild 2>&1 | indent
   npm --unsafe-perm prune 2>&1 | indent

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -134,8 +134,7 @@ install_and_cache_deps() {
 }
 
 install_npm_deps() {
-  npm prune | indent
-  npm install --quiet --unsafe-perm --userconfig $build_dir/.npmrc 2>&1 | indent
+  npm install --unsafe-perm --userconfig $build_dir/.npmrc 2>&1 | indent
   npm rebuild 2>&1 | indent
   npm --unsafe-perm prune 2>&1 | indent
 }

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -142,8 +142,9 @@ install_npm_deps() {
     info "Adding npm registry entry to .npmrc using environment variable NPM_TOKEN"
     echo "//registry.npmjs.org/:_authToken=${npm_token}" >> "${build_dir}/.npmrc"
   fi
-  npm prune --userconfig $build_dir/.npmrc
-  npm install --unsafe-perm --userconfig $build_dir/.npmrc 2>&1 | indent
+  
+  npm prune --userconfig $build_dir/.npmrc | indent
+  npm install --quiet --unsafe-perm --userconfig $build_dir/.npmrc 2>&1 | indent
   npm rebuild 2>&1 | indent
   npm --unsafe-perm prune 2>&1 | indent
 }

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -135,7 +135,7 @@ install_and_cache_deps() {
 
 install_npm_deps() {
   npm prune | indent
-  npm install --quiet --unsafe-perm --userconfig $build_dir/npmrc 2>&1 | indent
+  npm install --quiet --unsafe-perm --userconfig $build_dir/.npmrc 2>&1 | indent
   npm rebuild 2>&1 | indent
   npm --unsafe-perm prune 2>&1 | indent
 }


### PR DESCRIPTION
## Background

When `clear_cache` is enabled and the deploy is adding private packages (requiring an `.npmrc` file) the deploy will fail. This is due to the `npm prune` command missing the same `--userconfig` flag.

While I was in there, I integrated `NPM_TOKEN` support to generate an `.npmrc` like other buildpacks on Heroku support out-of-the-box.

## Feedback

I think I can refactor the generation code to use the ENV exports method from common.sh, but was not sure so I went with the safest option.