### PR TITLE
Phoenix 1.4 Upgrade

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -5,5 +5,5 @@ cat <<EOF
 addons:
   []
 default_process_types:
-  web: mix phx.server
+  web: elixir --sname server -S mix phx.server
 EOF

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -6,6 +6,7 @@ cleanup_cache() {
     rm -rf $cache_dir/node-version
     rm -rf $cache_dir/phoenix-static
     rm -rf $cache_dir/yarn-cache
+    rm -rf $cache_dir/node_modules
     cleanup_old_node
   fi
 }
@@ -45,9 +46,8 @@ cleanup_old_node() {
   # has the format "5.6.0"
 
   if [ $clean_cache = true ] || [ $old_node != v$node_version ] && [ -f $old_node_dir ]; then
-    info "Cleaning up old Node $old_node and old dependencies in cache"
+    info "Cleaning up old Node $old_node"
     rm $old_node_dir
-    rm -rf $cache_dir/node_modules
 
     local bower_components_dir=$cache_dir/bower_components
 
@@ -115,8 +115,6 @@ install_yarn() {
 }
 
 install_and_cache_deps() {
-  info "Installing and caching node modules"
-
   cd $assets_dir
 
   if [ -d $cache_dir/node_modules ]; then
@@ -125,6 +123,7 @@ install_and_cache_deps() {
     cp -R $cache_dir/node_modules/* node_modules/
   fi
 
+  info "Installing node modules"
   if [ -f "$assets_dir/yarn.lock" ]; then
     install_yarn_deps
   else

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -78,7 +78,7 @@ install_node() {
 install_npm() {
   # Optionally bootstrap a different npm version
   if [ ! $npm_version ] || [[ `npm --version` == "$npm_version" ]]; then
-    info "Using default npm version"
+    info "Using default npm version `npm --version`"
   else
     info "Downloading and installing npm $npm_version (replacing version `npm --version`)..."
     cd $build_dir

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -116,10 +116,13 @@ install_yarn() {
 
 install_and_cache_deps() {
   info "Installing and caching node modules"
+
   cd $assets_dir
+
   if [ -d $cache_dir/node_modules ]; then
-    mkdir -p node_modules
-    cp -r $cache_dir/node_modules/* node_modules/
+    info "Loading node modules from cache"
+    mkdir node_modules
+    cp -R $cache_dir/node_modules/* node_modules/
   fi
 
   if [ -f "$assets_dir/yarn.lock" ]; then
@@ -128,8 +131,11 @@ install_and_cache_deps() {
     install_npm_deps
   fi
 
-  cp -r node_modules $cache_dir
+  info "Caching node modules"
+  cp -R node_modules $cache_dir
+
   PATH=$assets_dir/node_modules/.bin:$PATH
+
   install_bower_deps
 }
 

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,6 +1,7 @@
 clean_cache=false
 compile="compile"
 node_version=12.14.1
+npm_version=6.13.7
 yarn_version=0.27.5
 phoenix_relative_path=.
 remove_node=false

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,6 +1,6 @@
 clean_cache=false
 compile="compile"
-node_version=6.9.2
+node_version=12.14.1
 yarn_version=0.27.5
 phoenix_relative_path=.
 remove_node=false


### PR DESCRIPTION
Thanks for the amazing work on this buildpack! I ran into a couple issues when setting this up with recent phoenix project:

* Use `--sname` to allow `iex` console sessions to connect to the running process
* Clear out `node_modules`, regardless of node/npm version, when `clean_cache` is enabled
* Use `cp -R` to avoid the build failing if a node module is symlinked. The latest [phoenix package.json](https://github.com/phoenixframework/phoenix/blob/cfb83d9eff1373d44a8d811e77b22beac0f9a42a/installer/templates/phx_assets/package.json#L10-L11) symlinks by default.