### PR TITLE
Allow only numbers and dots in versions

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -98,14 +98,14 @@ export_mix_env() {
 
 fix_node_version() {
   echo "node_version"
-  echo "$node_version"
-  node_version=$(echo "$node_version" | sed 's/[^0-9.]*//g')
-  echo "$node_version"
+  echo "${node_version}"
+  node_version=$(echo "${node_version}" | sed 's/[^0-9.]*//g')
+  echo "${node_version}"
 }
 
 fix_npm_version() {
   echo "npm_version"
-  echo "$npm_version"
-  npm_version=$(echo "$npm_version" | sed 's/[^0-9.]*//g')
-  echo "$npm_version"
+  echo "${npm_version}"
+  npm_version=$(echo "${npm_version}" | sed 's/[^0-9.]*//g')
+  echo "${npm_version}"
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -97,12 +97,14 @@ export_mix_env() {
 }
 
 fix_node_version() {
+  echo "node_version"
   echo "$node_version"
   node_version=$(echo "$node_version" | sed 's/[^0-9.]*//g')
   echo "$node_version"
 }
 
 fix_npm_version() {
+  echo "npm_version"
   echo "$npm_version"
   npm_version=$(echo "$npm_version" | sed 's/[^0-9.]*//g')
   echo "$npm_version"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -30,6 +30,8 @@ load_config() {
   # Source for default versions file from buildpack first
   source "${build_pack_dir}/phoenix_static_buildpack.config"
 
+  echo "$node_version"
+  echo "$npm_version"
   fix_node_version
   fix_npm_version
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -97,9 +97,13 @@ export_mix_env() {
 }
 
 fix_node_version() {
+  echo "$node_version"
   node_version=$(echo "$node_version" | sed 's/[^0-9.]*//g')
+  echo "$node_version"
 }
 
 fix_npm_version() {
+  echo "$npm_version"
   npm_version=$(echo "$npm_version" | sed 's/[^0-9.]*//g')
+  echo "$npm_version"
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -30,6 +30,9 @@ load_config() {
   # Source for default versions file from buildpack first
   source "${build_pack_dir}/phoenix_static_buildpack.config"
 
+  fix_node_version
+  fix_npm_version
+
   if [ -f $custom_config_file ]; then
     source $custom_config_file
   else
@@ -91,4 +94,12 @@ export_mix_env() {
   fi
 
   info "* MIX_ENV=${MIX_ENV}"
+}
+
+fix_node_version() {
+  node_version=$(echo "$node_version" | sed 's/[^0-9.]*//g')
+}
+
+fix_npm_version() {
+  npm_version=$(echo "$npm_version" | sed 's/[^0-9.]*//g')
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -30,17 +30,15 @@ load_config() {
   # Source for default versions file from buildpack first
   source "${build_pack_dir}/phoenix_static_buildpack.config"
 
-  echo "$node_version"
-  echo "$npm_version"
-  fix_node_version
-  fix_npm_version
-
   if [ -f $custom_config_file ]; then
     source $custom_config_file
   else
     info "The config file phoenix_static_buildpack.config wasn't found"
     info "Using the default config provided from the Phoenix static buildpack"
   fi
+
+  fix_node_version
+  fix_npm_version
 
   phoenix_dir=$build_dir/$phoenix_relative_path
 
@@ -99,15 +97,9 @@ export_mix_env() {
 }
 
 fix_node_version() {
-  echo "node_version"
-  echo "${node_version}"
   node_version=$(echo "${node_version}" | sed 's/[^0-9.]*//g')
-  echo "${node_version}"
 }
 
 fix_npm_version() {
-  echo "npm_version"
-  echo "${npm_version}"
   npm_version=$(echo "${npm_version}" | sed 's/[^0-9.]*//g')
-  echo "${npm_version}"
 }


### PR DESCRIPTION
We frequently encounter issues when there are stray characters such as ^M