### PR TITLE
Use a test config file for Heroku CI runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ assets_path=.
 phoenix_ex=phx
 ```
 
+### Heroku CI
+
+Additionally, you can create a `phoenix_static_buildpack.test.config` file that is specific for Heroku CI runs. Once defined, it will override the `phoenix_static_buildpack.config` values.
+
 ## Compile
 
 By default, Phoenix uses `brunch` and recommends you to use `mix phx.digest` in production. For that, we have a default `compile` shell script which gets run after building dependencies and

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -35,6 +35,7 @@ load_config() {
 
     # Source test config if running on Heroku CI
     if [ -n "$CI" ] && [ -f "${build_dir}/phoenix_static_buildpack.test.config" ]; then
+      info "Loading test config..."
       source "${build_dir}/phoenix_static_buildpack.test.config"
     fi
   else

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -34,7 +34,7 @@ load_config() {
     source $custom_config_file
 
     # Source test config if running on Heroku CI
-    if [ -n "$CI" ] && [ -f "${build_dir}/phoenix_static_buildpack.test.config" ]; then
+    if [ -d $env_dir ] && [ -f $env_dir/CI ] && [ -f "${build_dir}/phoenix_static_buildpack.test.config" ]; then
       info "Loading test config..."
       source "${build_dir}/phoenix_static_buildpack.test.config"
     fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -25,7 +25,13 @@ file_contents() {
 load_config() {
   info "Loading config..."
 
-  local custom_config_file="${build_dir}/phoenix_static_buildpack.config"
+  local custom_config_filename="phoenix_static_buildpack.config"
+
+  if [ -n "$CI" ] && [ -f "${build_dir}/phoenix_static_buildpack.test.config" ]; then
+    custom_config_filename="phoenix_static_buildpack.test.config"
+  fi
+
+  local custom_config_file="${build_dir}/${custom_config_filename}"
 
   # Source for default versions file from buildpack first
   source "${build_pack_dir}/phoenix_static_buildpack.config"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -25,19 +25,18 @@ file_contents() {
 load_config() {
   info "Loading config..."
 
-  local custom_config_filename="phoenix_static_buildpack.config"
-
-  if [ -n "$CI" ] && [ -f "${build_dir}/phoenix_static_buildpack.test.config" ]; then
-    custom_config_filename="phoenix_static_buildpack.test.config"
-  fi
-
-  local custom_config_file="${build_dir}/${custom_config_filename}"
+  local custom_config_file="${build_dir}/phoenix_static_buildpack.config"
 
   # Source for default versions file from buildpack first
   source "${build_pack_dir}/phoenix_static_buildpack.config"
 
   if [ -f $custom_config_file ]; then
     source $custom_config_file
+
+    # Source test config if running on Heroku CI
+    if [ -n "$CI" ] && [ -f "${build_dir}/phoenix_static_buildpack.test.config" ]; then
+      source "${build_dir}/phoenix_static_buildpack.test.config"
+    fi
   else
     info "The config file phoenix_static_buildpack.config wasn't found"
     info "Using the default config provided from the Phoenix static buildpack"


### PR DESCRIPTION
Source `phoenix_static_buildpack.test.config` if Heroku CI is running the build. It overrides the config set in `phoenix_static_buildpack.config`.

This is useful when, for example, we want to keep the cache folder for different CI runs, but not for production builds.