### PR TITLE
Only install production npm dependencies

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -142,7 +142,7 @@ install_and_cache_deps() {
 
 install_npm_deps() {
   npm prune | indent
-  npm install --quiet --unsafe-perm --userconfig $build_dir/npmrc 2>&1 | indent
+  npm install --only=prod --quiet --unsafe-perm --userconfig $build_dir/npmrc 2>&1 | indent
   npm rebuild 2>&1 | indent
   npm --unsafe-perm prune 2>&1 | indent
 }


### PR DESCRIPTION
We are hosted on `gigalixir` and were quite surprised to see that dev-only dependencies we had put at the root level (even though it's no longer the standard) were being installed, by default, and without the possibility of overriding this.

Would you consider installing only production dependencies?